### PR TITLE
Fix: Resolve Streamlit runtime error and label warnings

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[server]
+fileWatcherType = "none"

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -161,7 +161,7 @@ if st.button("Search 🔍"):
                             container.markdown(f"<small>Relevance Score (distance): {res['distance']:.4f} | Chunk ID: {res['chunk_id']}</small>", unsafe_allow_html=True)
                             
                             with container.expander("Show relevant text", expanded=False):
-                                st.text_area("", value=res['text'], height=200, key=f"text_area_{i}_{res['chunk_id']}") # Ensure unique key
+                                st.text_area(label=f"Relevant text content {i+1}", value=res['text'], height=200, key=f"text_area_{i}_{res['chunk_id']}", label_visibility="collapsed") # Ensure unique key
                             container.markdown("---")
                 else:
                      st.warning("No valid results to display after processing.")


### PR DESCRIPTION
Addresses two issues observed in Streamlit logs:

1.  `RuntimeError: no running event loop` coupled with a `torch.classes` error: This error appeared to stem from Streamlit's file watcher (`local_sources_watcher.py`) interacting incorrectly with PyTorch's `torch.classes` module structure during path inspection. The fix implements a common workaround by disabling the file watcher. A `.streamlit/config.toml` file has been added with the setting: ```toml [server] fileWatcherType = "none" ``` This prevents the watcher from running and triggering the error. The tradeoff is that hot reloading during development will be disabled.

2.  `label` got an empty value warnings: Multiple warnings indicated that some Streamlit input elements were missing labels. This was traced to `st.text_area` calls within a loop that used an empty string for the label. The `streamlit_app.py` has been updated to provide unique, descriptive, yet visually collapsed, labels for these text areas, e.g.: `st.text_area(label=f"Relevant text content {i+1}", ..., label_visibility="collapsed")` This resolves the accessibility warnings.