### PR TITLE
feat: Implement URL query parameter search

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,11 +209,22 @@
                     allIndexData = {}; // Ensure it's an empty object if fetch failed or was caught
                     // The warning is already logged in the catch block of the fetch itself.
                 }
-                
-                currentFilteredData = [...allCircularData]; // Initially, all data is filtered data
-                currentPage = 1;
-                displayResultsPage();
-                setupPagination();
+
+                // Handle URL query parameter for initial search
+                const urlParams = new URLSearchParams(window.location.search);
+                const queryFromUrl = urlParams.get('query');
+
+                if (queryFromUrl) {
+                    const decodedQuery = decodeURIComponent(queryFromUrl);
+                    searchInput.value = decodedQuery;
+                    performSearch(); // This will filter and then display results and pagination
+                } else {
+                    // If no query in URL, load all data as before
+                    currentFilteredData = [...allCircularData];
+                    currentPage = 1;
+                    displayResultsPage();
+                    setupPagination();
+                }
             } catch (error) {
                 console.error('Error loading data:', error);
                 resultsContainer.innerHTML = `<p class="error-message">Error loading data. Please ensure 'circular-data.json' is accessible. Details: ${error.message}</p>`;


### PR DESCRIPTION
This change modifies the index.html page to support initial search functionality based on a URL query parameter.

If you load the page with a `?query=<search_term>` parameter in the URL, the search input field will be automatically populated with the <search_term>, and a search will be performed when the page loads.

This allows you to share or bookmark URLs that link directly to specific search results.

The `loadAllData` JavaScript function was updated to:
- Parse URL parameters using `URLSearchParams`.
- Check for the presence of a `query` parameter.
- If found, decode its value, set it in the search input, and trigger the `performSearch` function.
- If not found, the page loads with all results as before.